### PR TITLE
Python<3.6 optimization

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 ignore = D203,E203
-max-complexity = 25
+max-complexity = 26
 max-line-length = 90

--- a/README.md
+++ b/README.md
@@ -164,15 +164,15 @@ fstr_setup = "import fstr\ntemplate = fstr('{x}' * 10)"
 str_result = timeit("template.format(x=1)", setup=str_setup, number=1000000)
 fstr_result = timeit("template.format(x=1)", setup=fstr_setup, number=1000000)
 
-print("str.format() : %s seconds" % str_result)
+print("str.format()  : %s seconds" % str_result)
 print("fstr.format() : %s seconds" % fstr_result)
 ```
 
 ### Python < 3.6
 
 ```
-str.format() : 0.741672992706 seconds
-fstr.format() : 6.77992010117 seconds
+str.format()  : 0.67650 seconds
+fstr.format() : 1.38063 seconds
 ```
 
 ### Python >= 3.6

--- a/fstr/__init__.py
+++ b/fstr/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0-alpha2"  # evaluated in setup.py
+__version__ = "0.1.0-alpha3"  # evaluated in setup.py
 
 import sys
 from .fstr import fstr

--- a/fstr/fstr.py
+++ b/fstr/fstr.py
@@ -93,7 +93,9 @@ class fstr(str):
             index = len(outside[0])  # only used for syntax error info
             for inner, outer in zip(inside, outside[1:]):
                 expr, format_lang = split_format_language(inner, self)
-                template_parts[-1]
+                if "\\" in expr:
+                    msg = "Backslash not allowed in expression."
+                    raise_syntax_error(self, msg, index + 1)
                 if "{" in format_lang:
                     # there's an fstring inside the format language
                     template_fstrs.append(fstr(format_lang, **self.__context))
@@ -105,7 +107,7 @@ class fstr(str):
                     msg = "Empty expresion not allowed."
                     raise_syntax_error(self, msg, index + 1)
                 expressions.append(expr.strip().replace("\n", ""))
-                index += len(inner) + len(outer)
+                index += len(inner) + len(outer) + 2
 
             template_parts = [
                 "".join(template_parts[i : i + 2])

--- a/fstr/fstr.py
+++ b/fstr/fstr.py
@@ -1,4 +1,3 @@
-import six
 import sys
 import inspect
 
@@ -115,8 +114,10 @@ class fstr(str):
 
             self.__template_parts = template_parts
             self.__template_fstrs = template_fstrs
-            self.__expressions = expressions
-            self.__code = [compile(e, "<fstr>", "eval") for e in expressions]
+            # form expressions into a tuple that can be evaluated once
+            tuple_expression_items = ["(\n   %s\n)," % e for e in expressions]
+            tuple_expression = "(\n%s\n)" % "\n".join(tuple_expression_items)
+            self.__code = compile(tuple_expression, "<fstr>", "eval")
 
         def format(self, **context):
             template = ""
@@ -126,15 +127,7 @@ class fstr(str):
                     template += tp + "{" + fs.format(**context) + "}"
             # if no template fstrs join parts otherwise append remaining parts.
             template += "".join(self.__template_parts[len(self.__template_fstrs) :])
-            values = []
-            for i, c in enumerate(self.__code):
-                try:
-                    result = eval(c, dict(self.__context, **context))
-                except Exception as e:
-                    msg = "Could not evaluate %r." % self.__expressions[i]
-                    raise six.raise_from(type(e)(msg), e)
-                else:
-                    values.append(result)
+            values = eval(self.__code, self.__context.copy(), context)
             try:
                 return template.format(*values)
             except ValueError as e:

--- a/fstr/utils.py
+++ b/fstr/utils.py
@@ -35,11 +35,14 @@ def split_format_language(string, full_template):
 def expr_starts_and_stops(string):
     index = 0
     brace_depth = 0
+    paren_depth = 0
     expression_starts = []
     expression_stops = []
     in_single_quote = False
     in_double_quote = False
     in_triple_quote = False
+    in_quotes = False
+    in_expression = False
 
     while index < len(string):
         char = string[index]
@@ -54,9 +57,10 @@ def expr_starts_and_stops(string):
                     in_triple_quote = not in_triple_quote
                 elif not in_triple_quote:
                     in_double_quote = not in_double_quote
+            in_quotes = in_double_quote or in_single_quote or in_triple_quote
         if char == "{":
             if brace_depth > 0:
-                if not (in_double_quote or in_single_quote):
+                if not in_quotes:
                     # increment open count to verify ballanced braces at end
                     brace_depth += 1
             else:
@@ -69,7 +73,8 @@ def expr_starts_and_stops(string):
                     # encountered odd number of open braces
                     expression_starts.append(index + 1)
                     brace_depth += 1
-        elif not (in_double_quote or in_single_quote) and char == "}":
+                    in_expression = True
+        elif char == "}" and not in_quotes:
             if brace_depth > 1:
                 brace_depth -= 1
             elif brace_depth == 1:
@@ -81,7 +86,16 @@ def expr_starts_and_stops(string):
                     # encountered odd number of open braces
                     expression_stops.append(index)
                     brace_depth -= 1
+                    in_expression = False
                 index += j
+        elif in_expression:
+            if char == "(":
+                paren_depth += 1
+            elif char == ")":
+                paren_depth -= 1
+                if paren_depth < 0:
+                    msg = "Mismatched parentheses in f-string"
+                    raise_syntax_error(string, msg, index + 1)
         index += 1
 
     if brace_depth:

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,6 @@ with open(os.path.join(root, "__init__.py")) as f:
         print("No version found in %s/__init__.py" % root)
         sys.exit(1)
 
-
-package["install_requires"] = ["six==1.11.0"]
-
 # -----------------------------------------------------------------------------
 # Library Description
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
By putting all expressions into a tuple expression eval() can be called once instead of N times where N is the number of expressions.